### PR TITLE
feat(specification-fields): Restrict creating indicators/subfields for control fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * add include parameter for GET specifications endpoint ([MRSPECS-28](https://folio-org.atlassian.net//browse/MRSPECS-28))
 * implement PUT/DELETE endpoints for indicators, indicator codes ([MRSPECS-25](https://folio-org.atlassian.net//browse/MRSPECS-25))
 * Send Kafka event in case of specification change ([MRSPECS-40](https://folio-org.atlassian.net//browse/MRSPECS-40))
+* Restrict creating indicators/subfields for control fields ([MRSPECS-39](https://folio-org.atlassian.net//browse/MRSPECS-39))
 
 #### Validator
 * implement validation by MARC specification ([MRSPECS-38](https://folio-org.atlassian.net//browse/MRSPECS-38))

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/config/ValidationConfig.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/config/ValidationConfig.java
@@ -1,8 +1,8 @@
 package org.folio.rspec.config;
 
 import jakarta.validation.constraints.NotNull;
-import org.folio.rspec.service.validation.NotNullValidator;
-import org.folio.rspec.service.validation.RegexpUrlValidator;
+import org.folio.rspec.service.validation.constraint.NotNullValidator;
+import org.folio.rspec.service.validation.constraint.RegexpUrlValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.constraints.URL;

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/controller/handler/ResourceValidationFailedExceptionHandler.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/controller/handler/ResourceValidationFailedExceptionHandler.java
@@ -1,0 +1,34 @@
+package org.folio.rspec.controller.handler;
+
+import static org.folio.rspec.domain.dto.ErrorCode.CONTROL_FIELD_RESOURCE_NOT_ALLOWED;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.rspec.domain.dto.ErrorCollection;
+import org.folio.rspec.exception.ResourceValidationFailedException;
+import org.folio.spring.i18n.service.TranslationService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ResourceValidationFailedExceptionHandler implements ServiceExceptionHandler {
+
+  private static final String PARAMETER_MSG_ARG = "parameter";
+
+  private final TranslationService translationService;
+
+  @Override
+  public ResponseEntity<ErrorCollection> handleException(Exception e) {
+    var exception = (ResourceValidationFailedException) e;
+    var messageKey = CONTROL_FIELD_RESOURCE_NOT_ALLOWED.getMessageKey();
+    var errorMessage = translationService.format(messageKey, PARAMETER_MSG_ARG, exception.getResource());
+    var error = ServiceExceptionHandler.fromErrorCode(CONTROL_FIELD_RESOURCE_NOT_ALLOWED)
+      .message(errorMessage);
+    return ResponseEntity.badRequest().body(new ErrorCollection().addErrorsItem(error));
+  }
+
+  @Override
+  public boolean canHandle(Exception e) {
+    return e instanceof ResourceValidationFailedException;
+  }
+}

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/domain/dto/ErrorCode.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/domain/dto/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
   DUPLICATE_INDICATOR_CODE("duplicate-indicator-code", "107", "indicator.code.code.duplicate"),
   DUPLICATE_SUBFIELD("duplicate-subfield-code", "108", "field.subfield.code.duplicate"),
   SCOPE_MODIFICATION_NOT_ALLOWED("scope-modification-not-allowed", "109", "scope.%s.not-allowed"),
+  CONTROL_FIELD_RESOURCE_NOT_ALLOWED("scope-modification-not-allowed", "110", "control-field.resource.not-allowed"),
   BAD_REQUEST("bad-request", "400", null),
   RESOURCE_NOT_FOUND("resource-not-found", "404", "specification.resource.not-found"),
   UNEXPECTED("unexpected", "500", "unexpected"),

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/exception/ResourceValidationFailedException.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/exception/ResourceValidationFailedException.java
@@ -1,0 +1,8 @@
+package org.folio.rspec.exception;
+
+public class ResourceValidationFailedException extends RuntimeException {
+
+  public ResourceValidationFailedException(String message) {
+    super(message);
+  }
+}

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/exception/ResourceValidationFailedException.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/exception/ResourceValidationFailedException.java
@@ -1,8 +1,14 @@
 package org.folio.rspec.exception;
 
+import lombok.Getter;
+
+@Getter
 public class ResourceValidationFailedException extends RuntimeException {
 
-  public ResourceValidationFailedException(String message) {
+  private final String resource;
+
+  public ResourceValidationFailedException(String resource, String message) {
     super(message);
+    this.resource = resource;
   }
 }

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/SpecificationFieldService.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/SpecificationFieldService.java
@@ -21,12 +21,15 @@ import org.folio.rspec.domain.dto.SubfieldChangeDto;
 import org.folio.rspec.domain.dto.SubfieldDto;
 import org.folio.rspec.domain.dto.SubfieldDtoCollection;
 import org.folio.rspec.domain.entity.Field;
+import org.folio.rspec.domain.entity.Indicator;
 import org.folio.rspec.domain.entity.Specification;
+import org.folio.rspec.domain.entity.Subfield;
 import org.folio.rspec.domain.repository.FieldRepository;
 import org.folio.rspec.exception.ResourceNotFoundException;
 import org.folio.rspec.exception.ScopeModificationNotAllowedException;
 import org.folio.rspec.integration.kafka.EventProducer;
 import org.folio.rspec.service.mapper.FieldMapper;
+import org.folio.rspec.service.validation.resource.FieldValidator;
 import org.folio.rspec.service.validation.scope.ScopeValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -41,6 +44,7 @@ public class SpecificationFieldService {
   private final FieldMapper fieldMapper;
   private final FieldIndicatorService indicatorService;
   private final SubfieldService subfieldService;
+  private final FieldValidator fieldValidator;
   private final EventProducer<UUID, SpecificationUpdatedEvent> eventProducer;
 
   private Map<Scope, ScopeValidator<SpecificationFieldChangeDto, Field>> fieldValidators = new EnumMap<>(Scope.class);
@@ -113,6 +117,7 @@ public class SpecificationFieldService {
     log.debug("createLocalIndicator::fieldId={}, createDto={}", fieldId, createDto);
     return doForFieldOrFail(fieldId,
       field -> {
+        fieldValidator.validateFieldResourceCreate(field, Indicator.INDICATOR_TABLE_NAME);
         var indicator = indicatorService.createLocalIndicator(field, createDto);
         eventProducer.sendEvent(field.getSpecification().getId());
         return indicator;
@@ -131,6 +136,7 @@ public class SpecificationFieldService {
     log.debug("createLocalSubfield::fieldId={}, createDto={}", fieldId, createDto);
     return doForFieldOrFail(fieldId,
       field -> {
+        fieldValidator.validateFieldResourceCreate(field, Subfield.SUBFIELD_TABLE_NAME);
         var dto = subfieldService.createLocalSubfield(field, createDto);
         eventProducer.sendEvent(field.getSpecification().getId());
         return dto;

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/constraint/NotNullValidator.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/constraint/NotNullValidator.java
@@ -1,4 +1,4 @@
-package org.folio.rspec.service.validation;
+package org.folio.rspec.service.validation.constraint;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/constraint/RegexpUrlValidator.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/constraint/RegexpUrlValidator.java
@@ -5,7 +5,7 @@
  * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
  */
 
-package org.folio.rspec.service.validation;
+package org.folio.rspec.service.validation.constraint;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/resource/FieldValidator.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/resource/FieldValidator.java
@@ -1,0 +1,18 @@
+package org.folio.rspec.service.validation.resource;
+
+import org.folio.rspec.domain.entity.Field;
+import org.folio.rspec.exception.ResourceValidationFailedException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FieldValidator {
+
+  private static final String ERROR_MESSAGE = "Cannot define %s for control numbers";
+  private static final String CONTROL_FIELD_TAG_START = "00";
+
+  public void validateFieldResourceCreate(Field field, String resource) {
+    if (field.getTag().startsWith(CONTROL_FIELD_TAG_START)) {
+      throw new ResourceValidationFailedException(ERROR_MESSAGE.formatted(resource));
+    }
+  }
+}

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/resource/FieldValidator.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/validation/resource/FieldValidator.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class FieldValidator {
 
-  private static final String ERROR_MESSAGE = "Cannot define %s for control numbers";
+  private static final String ERROR_MESSAGE = "Cannot define %s for control numbers.";
   private static final String CONTROL_FIELD_TAG_START = "00";
 
   public void validateFieldResourceCreate(Field field, String resource) {
     if (field.getTag().startsWith(CONTROL_FIELD_TAG_START)) {
-      throw new ResourceValidationFailedException(ERROR_MESSAGE.formatted(resource));
+      throw new ResourceValidationFailedException(resource, ERROR_MESSAGE.formatted(resource));
     }
   }
 }

--- a/mod-record-specifications-server/src/test/java/org/folio/api/SpecificationStorageFieldsApiIT.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/api/SpecificationStorageFieldsApiIT.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.folio.rspec.domain.dto.ErrorCode;
 import org.folio.rspec.domain.repository.FieldRepository;
 import org.folio.rspec.exception.ResourceNotFoundException;
+import org.folio.rspec.exception.ResourceValidationFailedException;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
@@ -208,6 +209,18 @@ class SpecificationStorageFieldsApiIT extends SpecificationITBase {
   }
 
   @Test
+  void createFieldLocalIndicator_shouldReturn400WhenControlField() throws Exception {
+    var fieldId = createLocalField("005");
+    var dto = localTestIndicator(1);
+
+    tryPost(fieldIndicatorsPath(fieldId), dto)
+      .andExpect(status().isBadRequest())
+      .andExpect(exceptionMatch(ResourceValidationFailedException.class))
+      .andExpect(errorTypeMatch(is(ErrorCode.CONTROL_FIELD_RESOURCE_NOT_ALLOWED.getType())))
+      .andExpect(errorMessageMatch(is("Cannot define indicator for control numbers.")));
+  }
+
+  @Test
   void getFieldSubfields_shouldReturn200AndAllSubfieldsForField() throws Exception {
     var fieldId = createLocalField("103");
     var sub1 = localTestSubfield("a", "Subfield a");
@@ -271,6 +284,18 @@ class SpecificationStorageFieldsApiIT extends SpecificationITBase {
       .andExpect(exceptionMatch(DataIntegrityViolationException.class))
       .andExpect(errorTypeMatch(is(ErrorCode.DUPLICATE_SUBFIELD.getType())))
       .andExpect(errorMessageMatch(is("The 'code' must be unique.")));
+  }
+
+  @Test
+  void createFieldLocalSubfield_shouldReturn400_whenControlField() throws Exception {
+    var fieldId = createLocalField("004");
+    var dto = localTestSubfield("a", "Subfield a");
+
+    tryPost(fieldSubfieldsPath(fieldId), dto)
+      .andExpect(status().isBadRequest())
+      .andExpect(exceptionMatch(ResourceValidationFailedException.class))
+      .andExpect(errorTypeMatch(is(ErrorCode.CONTROL_FIELD_RESOURCE_NOT_ALLOWED.getType())))
+      .andExpect(errorMessageMatch(is("Cannot define subfield for control numbers.")));
   }
 
   private Object getRecordId(MvcResult result) throws UnsupportedEncodingException {

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/validation/constraint/RegexpUrlValidatorTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/validation/constraint/RegexpUrlValidatorTest.java
@@ -1,4 +1,4 @@
-package org.folio.rspec.service.validation;
+package org.folio.rspec.service.validation.constraint;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/validation/resource/FieldValidatorTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/validation/resource/FieldValidatorTest.java
@@ -1,0 +1,40 @@
+package org.folio.rspec.service.validation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.support.builders.FieldBuilder.local;
+
+import org.folio.rspec.exception.ResourceValidationFailedException;
+import org.folio.spring.testing.extension.Random;
+import org.folio.spring.testing.extension.impl.RandomParametersExtension;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@UnitTest
+@ExtendWith(RandomParametersExtension.class)
+class FieldValidatorTest {
+
+  private final FieldValidator validator = new FieldValidator();
+
+  @ParameterizedTest
+  @ValueSource(strings = {"010", "100", "111", "220", "310", "414", "512", "635", "789", "871", "993"})
+  void validateFieldResourceCreate_positive(String fieldTag) {
+    var resource = "test";
+    var field = local().tag(fieldTag).buildEntity();
+
+    validator.validateFieldResourceCreate(field, resource);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"000", "001", "005", "009"})
+  void validateFieldResourceCreate_negative(String fieldTag, @Random String resource) {
+    var field = local().tag(fieldTag).buildEntity();
+
+    var result = Assertions.assertThrows(ResourceValidationFailedException.class,
+      () -> validator.validateFieldResourceCreate(field, resource));
+
+    assertThat(result.getMessage()).contains(resource);
+  }
+}

--- a/translations/mod-record-specifications/en.json
+++ b/translations/mod-record-specifications/en.json
@@ -7,6 +7,7 @@
   "specification.fetch.failed": "Specification fetching failed.",
   "scope.update.not-allowed": "The ''{parameter}'' modification is not allowed for {scope} scope.",
   "scope.delete.not-allowed": "A {scope} scope {parameter} cannot be deleted.",
+  "control-field.resource.not-allowed": "Cannot define {parameter} for control numbers.",
 
   "invalid.request.query-param.enum": "Unexpected value [{invalidValue}]. Possible values: [{possibleValues}].",
   "Pattern.SpecificationFieldChangeDto.tag": "A ''{parameter}'' field must contain three characters and can only accept numbers 0-9.",


### PR DESCRIPTION
### Purpose
Restrict creating indicators/subfields for control fields

### Approach
Add control field validation on indicator creation
Add control field validation on subfield creation
No abstractions added because no other validators with the same logic expected

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-39](https://folio-org.atlassian.net/browse/MRSPECS-39)
