### PR TITLE
feat(subfields-validation) implement "Non-Repeatable Subfield" Rule Validation

### DIFF
--- a/.github/workflows/build-dependants.yml
+++ b/.github/workflows/build-dependants.yml
@@ -57,7 +57,7 @@ jobs:
             !~/.m2/repository/org/folio/mod-record-specifications
           key: mod-quick-marc-${{ hashFiles('**/pom.xml') }}
           restore-keys: mod-quick-marc-
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: mod-record-specifications
           path: ~/.m2/repository/org/folio/mod-record-specifications

--- a/.github/workflows/build-dependants.yml
+++ b/.github/workflows/build-dependants.yml
@@ -32,7 +32,7 @@ jobs:
           key: mod-record-specifications-${{ hashFiles('**/pom.xml') }}
           restore-keys: mod-record-specifications-
       - run: mvn -B clean install -DskipTests
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: mod-record-specifications
           path: ~/.m2/repository/org/folio/mod-record-specifications

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 * implement Undefined Indicator validation ([MRSPECS-46](https://folio-org.atlassian.net/browse/MRSPECS-46))
 * implement Missing Subfield validation([MRSPECS-47](https://folio-org.atlassian.net/browse/MRSPECS-47))
 * implement Undefined Subfield validation ([MRSPECS-49](https://folio-org.atlassian.net/browse/MRSPECS-49))
+* implement Non-Repeatable Subfield validation ([MRSPECS-48](https://folio-org.atlassian.net/browse/MRSPECS-48))
 
 #### General
 * Implement build dependants GitHub workflow on PR creation ([MRSPECS-9](https://folio-org.atlassian.net//browse/MRSPECS-9))

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/utils/SpecificationUtils.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/utils/SpecificationUtils.java
@@ -43,4 +43,11 @@ public class SpecificationUtils {
       .filter(subfield -> Boolean.TRUE.equals(subfield.getRequired()))
       .collect(Collectors.toMap(subfield -> subfield.getCode().charAt(0), Function.identity()));
   }
+
+  public static Map<Character, SubfieldDto> nonRepeatableSubfields(List<SubfieldDto> subfieldDto) {
+    return subfieldDto == null ? Map.of() : subfieldDto
+      .stream()
+      .filter(subfield -> Boolean.FALSE.equals(subfield.getRepeatable()))
+      .collect(Collectors.toMap(subfield -> subfield.getCode().charAt(0), Function.identity()));
+  }
 }

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/utils/SpecificationUtils.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/utils/SpecificationUtils.java
@@ -44,8 +44,8 @@ public class SpecificationUtils {
       .collect(Collectors.toMap(subfield -> subfield.getCode().charAt(0), Function.identity()));
   }
 
-  public static Map<Character, SubfieldDto> nonRepeatableSubfields(List<SubfieldDto> subfieldDto) {
-    return subfieldDto == null ? Map.of() : subfieldDto
+  public static Map<Character, SubfieldDto> nonRepeatableSubfields(List<SubfieldDto> subfieldDtos) {
+    return subfieldDtos == null ? Map.of() : subfieldDtos
       .stream()
       .filter(subfield -> Boolean.FALSE.equals(subfield.getRepeatable()))
       .collect(Collectors.toMap(subfield -> subfield.getCode().charAt(0), Function.identity()));

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MarcRecordRuleValidator.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MarcRecordRuleValidator.java
@@ -45,7 +45,8 @@ public class MarcRecordRuleValidator implements SpecificationRuleValidator<MarcR
     );
     this.subfieldValidators = List.of(
       new MissingSubfieldRuleValidator(translationProvider),
-      new UndefinedSubfieldRuleValidator(translationProvider));
+      new UndefinedSubfieldRuleValidator(translationProvider),
+      new NonRepeatableSubfieldRuleValidator(translationProvider));
   }
 
   @Override

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MissingSubfieldRuleValidator.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MissingSubfieldRuleValidator.java
@@ -65,8 +65,14 @@ public class MissingSubfieldRuleValidator
   }
 
   private boolean isMissing(List<MarcSubfield> marcSubfields, Character subFieldCode) {
-    return CollectionUtils.isEmpty(marcSubfields) || marcSubfields.stream()
-      .noneMatch(subfield -> isSubfieldEquals(subfield, subFieldCode) && StringUtils.isNotBlank(subfield.value()));
+    var requiredSubfields = marcSubfields.stream()
+      .filter(subfield -> isSubfieldEquals(subfield, subFieldCode))
+      .toList();
+    return CollectionUtils.isEmpty(requiredSubfields) || containsEmptySubfieldValue(requiredSubfields);
+  }
+
+  private boolean containsEmptySubfieldValue(List<MarcSubfield> requiredSubfields) {
+    return requiredSubfields.stream().anyMatch(subField -> StringUtils.isBlank(subField.value()));
   }
 
   private boolean isSubfieldEquals(MarcSubfield subfield, Character subFieldCode) {

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MissingSubfieldRuleValidator.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/MissingSubfieldRuleValidator.java
@@ -65,14 +65,8 @@ public class MissingSubfieldRuleValidator
   }
 
   private boolean isMissing(List<MarcSubfield> marcSubfields, Character subFieldCode) {
-    var requiredSubfields = marcSubfields.stream()
-      .filter(subfield -> isSubfieldEquals(subfield, subFieldCode))
-      .toList();
-    return CollectionUtils.isEmpty(requiredSubfields) || containsEmptySubfieldValue(requiredSubfields);
-  }
-
-  private boolean containsEmptySubfieldValue(List<MarcSubfield> requiredSubfields) {
-    return requiredSubfields.stream().anyMatch(subField -> StringUtils.isBlank(subField.value()));
+    return CollectionUtils.isEmpty(marcSubfields) || marcSubfields.stream()
+      .noneMatch(subfield -> isSubfieldEquals(subfield, subFieldCode) && StringUtils.isNotBlank(subfield.value()));
   }
 
   private boolean isSubfieldEquals(MarcSubfield subfield, Character subFieldCode) {

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidator.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidator.java
@@ -1,7 +1,6 @@
 package org.folio.rspec.validation.validator.marc.impl;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.folio.rspec.domain.dto.DefinitionType;
 import org.folio.rspec.domain.dto.SeverityType;
 import org.folio.rspec.domain.dto.SpecificationFieldDto;
@@ -30,11 +29,9 @@ public class NonRepeatableSubfieldRuleValidator
     var nonRepeatableSubfields = SpecificationUtils.nonRepeatableSubfields(specification.getSubfields());
 
     return marcSubfields.stream()
-      .collect(Collectors.groupingBy(MarcSubfield::code))
-      .entrySet()
-      .stream()
-      .filter(subfield -> subfield.getValue().size() > 1 && nonRepeatableSubfields.get(subfield.getKey()) != null)
-      .map(subfield -> buildError(subfield.getValue().get(0), nonRepeatableSubfields.get(subfield.getKey())))
+      .filter(subfield ->
+        subfield.reference().getSubfieldIndex() > 0 && nonRepeatableSubfields.get(subfield.code()) != null)
+      .map(subfield -> buildError(subfield, nonRepeatableSubfields.get(subfield.code())))
       .toList();
   }
 

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidator.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidator.java
@@ -1,0 +1,67 @@
+package org.folio.rspec.validation.validator.marc.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.folio.rspec.domain.dto.DefinitionType;
+import org.folio.rspec.domain.dto.SeverityType;
+import org.folio.rspec.domain.dto.SpecificationFieldDto;
+import org.folio.rspec.domain.dto.SubfieldDto;
+import org.folio.rspec.domain.dto.ValidationError;
+import org.folio.rspec.i18n.TranslationProvider;
+import org.folio.rspec.utils.SpecificationUtils;
+import org.folio.rspec.validation.validator.SpecificationRuleCode;
+import org.folio.rspec.validation.validator.SpecificationRuleValidator;
+import org.folio.rspec.validation.validator.marc.model.MarcRuleCode;
+import org.folio.rspec.validation.validator.marc.model.MarcSubfield;
+
+public class NonRepeatableSubfieldRuleValidator
+  implements SpecificationRuleValidator<List<MarcSubfield>, SpecificationFieldDto> {
+
+  private static final String CODE_KEY = "code";
+
+  private final TranslationProvider translationProvider;
+
+  NonRepeatableSubfieldRuleValidator(TranslationProvider translationProvider) {
+    this.translationProvider = translationProvider;
+  }
+
+  @Override
+  public List<ValidationError> validate(List<MarcSubfield> marcSubfields, SpecificationFieldDto specification) {
+    var nonRepeatableSubfields = SpecificationUtils.nonRepeatableSubfields(specification.getSubfields());
+
+    return marcSubfields.stream()
+      .collect(Collectors.groupingBy(MarcSubfield::code))
+      .entrySet()
+      .stream()
+      .filter(subfield -> subfield.getValue().size() > 1 && nonRepeatableSubfields.get(subfield.getKey()) != null)
+      .map(subfield -> buildError(subfield.getValue().get(0), nonRepeatableSubfields.get(subfield.getKey())))
+      .toList();
+  }
+
+  @Override
+  public SpecificationRuleCode supportedRule() {
+    return MarcRuleCode.NON_REPEATABLE_SUBFIELD;
+  }
+
+  @Override
+  public DefinitionType definitionType() {
+    return DefinitionType.SUBFIELD;
+  }
+
+  @Override
+  public SeverityType severity() {
+    return SeverityType.ERROR;
+  }
+
+  private ValidationError buildError(MarcSubfield marcSubfield, SubfieldDto subfieldDto) {
+    var message = translationProvider.format(ruleCode(), CODE_KEY, marcSubfield.code());
+    return ValidationError.builder()
+      .path(marcSubfield.reference().toString())
+      .definitionType(definitionType())
+      .definitionId(subfieldDto != null ? subfieldDto.getId() : null)
+      .severity(severity())
+      .ruleCode(ruleCode())
+      .message(message)
+      .build();
+  }
+}

--- a/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/model/MarcRuleCode.java
+++ b/mod-record-specifications-validator/src/main/java/org/folio/rspec/validation/validator/marc/model/MarcRuleCode.java
@@ -13,7 +13,8 @@ public enum MarcRuleCode implements SpecificationRuleCode {
   UNDEFINED_INDICATOR("undefinedIndicatorCode"),
   INVALID_INDICATOR("invalidIndicator"),
   MISSING_SUBFIELD("missingSubfield"),
-  UNDEFINED_SUBFIELD("undefinedSubfield");
+  UNDEFINED_SUBFIELD("undefinedSubfield"),
+  NON_REPEATABLE_SUBFIELD("nonRepeatableSubfield");
 
   private final String code;
 

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/utils/SpecificationUtilsTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/utils/SpecificationUtilsTest.java
@@ -84,16 +84,29 @@ class SpecificationUtilsTest {
   void requiredSubfields_returnsRequiredSubfields() {
     Map<Character, SubfieldDto> result = SpecificationUtils.requiredSubfields(
       List.of(
-        getSubfieldDto('a', true),
-        getSubfieldDto('b', false),
-        getSubfieldDto('c', true)));
+        getSubfieldDto('a', true, true),
+        getSubfieldDto('b', false, true),
+        getSubfieldDto('c', true, true)));
 
     assertEquals(2, result.size());
     assertTrue(result.containsKey('a'));
     assertTrue(result.containsKey('c'));
   }
 
-  private SubfieldDto getSubfieldDto(Character code, boolean isRequired) {
-    return new SubfieldDto().code(code.toString()).required(isRequired);
+  @Test
+  void nonRepeatableSubfields_returnsNonRepeatableSubfields() {
+    Map<Character, SubfieldDto> result = SpecificationUtils.nonRepeatableSubfields(
+      List.of(
+        getSubfieldDto('a', true, true),
+        getSubfieldDto('b', false, false),
+        getSubfieldDto('c', true, false)));
+
+    assertEquals(2, result.size());
+    assertTrue(result.containsKey('b'));
+    assertTrue(result.containsKey('c'));
+  }
+
+  private SubfieldDto getSubfieldDto(Character code, boolean isRequired, boolean isRepeatable) {
+    return new SubfieldDto().code(code.toString()).required(isRequired).repeatable(isRepeatable);
   }
 }

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
@@ -168,12 +168,12 @@ class MarcSpecificationGuidedValidatorTest {
       .hasSize(6)
       .extracting(ValidationError::getPath, ValidationError::getRuleCode)
       .containsExactlyInAnyOrder(
-        tuple("100[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("100[0]$d[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
         tuple("100[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
-        tuple("650[0]$w[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
-        tuple("047[0]$w[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
-        tuple("047[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
-        tuple("245[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode())
+        tuple("650[0]$w[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("047[0]$w[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("047[0]$d[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("245[0]$d[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode())
       );
   }
 

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
@@ -125,7 +125,7 @@ class MarcSpecificationGuidedValidatorTest {
     var marc4jRecord = TestRecordProvider.getMarc4jRecord("testdata/subfields/marc-subfield-record.json");
     var validationErrors = validator.validate(marc4jRecord, getSpecificationWithSubfields());
     assertThat(validationErrors)
-      .hasSize(9)
+      .hasSize(8)
       .extracting(ValidationError::getPath, ValidationError::getRuleCode)
       .containsExactlyInAnyOrder(
         tuple("650[0]$a[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
@@ -135,8 +135,7 @@ class MarcSpecificationGuidedValidatorTest {
         tuple("245[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
         tuple("246[0]$a[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
         tuple("246[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
-        tuple("010[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
-        tuple("100[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode())
+        tuple("010[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode())
       );
   }
 
@@ -165,11 +164,10 @@ class MarcSpecificationGuidedValidatorTest {
       "testdata/subfields/marc-non-repeatable-subfields-record.json");
     var validationErrors = validator.validate(marc4jRecord, getSpecificationWithNonRepeatableSubfields());
     assertThat(validationErrors)
-      .hasSize(6)
+      .hasSize(5)
       .extracting(ValidationError::getPath, ValidationError::getRuleCode)
       .containsExactlyInAnyOrder(
         tuple("100[0]$d[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
-        tuple("100[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
         tuple("650[0]$w[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
         tuple("047[0]$w[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
         tuple("047[0]$d[1]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/MarcSpecificationGuidedValidatorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.folio.support.TestDataProvider.getSpecification;
 import static org.folio.support.TestDataProvider.getSpecificationWithIndicators;
+import static org.folio.support.TestDataProvider.getSpecificationWithNonRepeatableSubfields;
 import static org.folio.support.TestDataProvider.getSpecificationWithSubfields;
 import static org.folio.support.TestDataProvider.getSpecificationWithTags;
 
@@ -124,7 +125,7 @@ class MarcSpecificationGuidedValidatorTest {
     var marc4jRecord = TestRecordProvider.getMarc4jRecord("testdata/subfields/marc-subfield-record.json");
     var validationErrors = validator.validate(marc4jRecord, getSpecificationWithSubfields());
     assertThat(validationErrors)
-      .hasSize(8)
+      .hasSize(9)
       .extracting(ValidationError::getPath, ValidationError::getRuleCode)
       .containsExactlyInAnyOrder(
         tuple("650[0]$a[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
@@ -134,7 +135,8 @@ class MarcSpecificationGuidedValidatorTest {
         tuple("245[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
         tuple("246[0]$a[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
         tuple("246[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
-        tuple("010[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode())
+        tuple("010[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
+        tuple("100[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode())
       );
   }
 
@@ -154,6 +156,24 @@ class MarcSpecificationGuidedValidatorTest {
         tuple("047[0]$f[0]", MarcRuleCode.UNDEFINED_SUBFIELD.getCode()),
         tuple("047[0]$r[0]", MarcRuleCode.UNDEFINED_SUBFIELD.getCode()),
         tuple("245[0]$c[0]", MarcRuleCode.UNDEFINED_SUBFIELD.getCode())
+      );
+  }
+
+  @Test
+  void testNonRepeatableSubfieldValidation() {
+    var marc4jRecord = TestRecordProvider.getMarc4jRecord(
+      "testdata/subfields/marc-non-repeatable-subfields-record.json");
+    var validationErrors = validator.validate(marc4jRecord, getSpecificationWithNonRepeatableSubfields());
+    assertThat(validationErrors)
+      .hasSize(6)
+      .extracting(ValidationError::getPath, ValidationError::getRuleCode)
+      .containsExactlyInAnyOrder(
+        tuple("100[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("100[0]$d[0]", MarcRuleCode.MISSING_SUBFIELD.getCode()),
+        tuple("650[0]$w[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("047[0]$w[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("047[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode()),
+        tuple("245[0]$d[0]", MarcRuleCode.NON_REPEATABLE_SUBFIELD.getCode())
       );
   }
 

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidatorTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidatorTest.java
@@ -27,19 +27,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-public class UndefinedSubfieldRuleValidatorTest {
+public class NonRepeatableSubfieldRuleValidatorTest {
 
   @Mock
   private TranslationProvider translationProvider;
   @InjectMocks
-  private UndefinedSubfieldRuleValidator validator;
+  private NonRepeatableSubfieldRuleValidator validator;
+
 
   @ParameterizedTest
-  @MethodSource("undefinedSubfieldTestSource")
-  void validate_whenUndefinedSubfield_shouldReturnValidationError(char subfield1, char subfield2) {
+  @MethodSource("nonRepeatableSubfieldTestSource")
+  void validate_whenNonRepeatableSubfield_shouldReturnValidationError(char subfield1, char subfield2, char subfield3) {
     when(translationProvider.format(any(), any(), any())).thenReturn("message");
 
-    var errors = validator.validate(getSubfields(subfield1, subfield2), getFieldDefinition());
+    var errors = validator.validate(
+      List.of(getSubfield(subfield1), getSubfield(subfield2), getSubfield(subfield3)), getFieldDefinition());
 
     assertEquals(1, errors.size());
     ValidationError error = errors.get(0);
@@ -50,17 +52,18 @@ public class UndefinedSubfieldRuleValidatorTest {
   }
 
   @Test
-  void validate_whenUndefinedSubfield_shouldReturnEmptyList() {
-    List<ValidationError> errors = validator.validate(getSubfields('a', 'b'), getFieldDefinition());
+  void validate_whenNonRepeatableSubfield_shouldReturnEmptyList() {
+    List<ValidationError> errors = validator.validate(
+      List.of(getSubfield('f'), getSubfield('b'), getSubfield('t')), getFieldDefinition());
 
     assertTrue(errors.isEmpty());
   }
 
-  public static Stream<Arguments> undefinedSubfieldTestSource() {
+  public static Stream<Arguments> nonRepeatableSubfieldTestSource() {
     return Stream.of(
-      arguments('f', 'a'),
-      arguments('c', 'b'),
-      arguments('t', 'k'));
+      arguments('f', 'a', 'f'),
+      arguments('c', 'b', 'b'),
+      arguments('t', 't', 'k'));
   }
 
   private static SpecificationFieldDto getFieldDefinition() {
@@ -69,15 +72,15 @@ public class UndefinedSubfieldRuleValidatorTest {
       .repeatable(false)
       .tag("tag")
       .subfields(List.of(
-        new SubfieldDto().code("a"),
-        new SubfieldDto().code("b"),
-        new SubfieldDto().code("k")));
+        new SubfieldDto().code("a").repeatable(true),
+        new SubfieldDto().code("c").repeatable(true),
+        new SubfieldDto().code("k").repeatable(true),
+        new SubfieldDto().code("b").repeatable(false),
+        new SubfieldDto().code("f").repeatable(false),
+        new SubfieldDto().code("t").repeatable(false)));
   }
 
-  private static List<MarcSubfield> getSubfields(char subfield1, char subfield2) {
-    return List.of(
-      new MarcSubfield(Reference.forSubfield(Reference.forTag("tag"), subfield1), "subfield value"),
-      new MarcSubfield(Reference.forSubfield(Reference.forTag("tag"), subfield2), "subfield value")
-    );
+  private static MarcSubfield getSubfield(char subfield) {
+    return new MarcSubfield(Reference.forSubfield(Reference.forTag("tag"), subfield), "subfield value");
   }
 }

--- a/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidatorTest.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/rspec/validation/validator/marc/impl/NonRepeatableSubfieldRuleValidatorTest.java
@@ -41,7 +41,11 @@ public class NonRepeatableSubfieldRuleValidatorTest {
     when(translationProvider.format(any(), any(), any())).thenReturn("message");
 
     var errors = validator.validate(
-      List.of(getSubfield(subfield1), getSubfield(subfield2), getSubfield(subfield3)), getFieldDefinition());
+      List.of(
+        getSubfield(subfield1, 0),
+        getSubfield(subfield2, 0),
+        getSubfield(subfield3, 1)),
+      getFieldDefinition());
 
     assertEquals(1, errors.size());
     ValidationError error = errors.get(0);
@@ -54,16 +58,20 @@ public class NonRepeatableSubfieldRuleValidatorTest {
   @Test
   void validate_whenNonRepeatableSubfield_shouldReturnEmptyList() {
     List<ValidationError> errors = validator.validate(
-      List.of(getSubfield('f'), getSubfield('b'), getSubfield('t')), getFieldDefinition());
+      List.of(
+        getSubfield('f', 0),
+        getSubfield('b', 0),
+        getSubfield('t', 0)),
+      getFieldDefinition());
 
     assertTrue(errors.isEmpty());
   }
 
   public static Stream<Arguments> nonRepeatableSubfieldTestSource() {
     return Stream.of(
-      arguments('f', 'a', 'f'),
+      arguments('a', 'f', 'f'),
       arguments('c', 'b', 'b'),
-      arguments('t', 't', 'k'));
+      arguments('k', 't', 't'));
   }
 
   private static SpecificationFieldDto getFieldDefinition() {
@@ -80,7 +88,7 @@ public class NonRepeatableSubfieldRuleValidatorTest {
         new SubfieldDto().code("t").repeatable(false)));
   }
 
-  private static MarcSubfield getSubfield(char subfield) {
-    return new MarcSubfield(Reference.forSubfield(Reference.forTag("tag"), subfield), "subfield value");
+  private static MarcSubfield getSubfield(char subfield, int subfieldIndex) {
+    return new MarcSubfield(Reference.forSubfield(Reference.forTag("tag"), subfield, subfieldIndex), "subfield value");
   }
 }

--- a/mod-record-specifications-validator/src/test/java/org/folio/support/TestDataProvider.java
+++ b/mod-record-specifications-validator/src/test/java/org/folio/support/TestDataProvider.java
@@ -52,6 +52,25 @@ public class TestDataProvider {
       .fields(subfieldDefinitions());
   }
 
+  public static SpecificationDto getSpecificationWithNonRepeatableSubfields() {
+    return new SpecificationDto()
+      .id(UUID.randomUUID())
+      .family(Family.MARC)
+      .profile(FamilyProfile.BIBLIOGRAPHIC)
+      .rules(allEnabledRules())
+      .fields(getNonRepeatableSubfieldDefinitions());
+  }
+
+  private static List<SpecificationFieldDto> getNonRepeatableSubfieldDefinitions() {
+    return List.of(requiredNonRepeatableField("000"),
+      defaultFieldWithNonRepeatableSubfields("010"),
+      defaultFieldWithNonRepeatableSubfields("035"),
+      defaultFieldWithNonRepeatableSubfields("047"),
+      defaultFieldWithNonRepeatableSubfields("100"),
+      defaultFieldWithNonRepeatableSubfields("245"),
+      defaultFieldWithNonRepeatableSubfields("650"));
+  }
+
   private static List<SpecificationFieldDto> commonFieldDefinitions() {
     List<SpecificationFieldDto> fields = new ArrayList<>();
     fields.add(requiredNonRepeatableField("000"));
@@ -122,11 +141,21 @@ public class TestDataProvider {
 
   private static SpecificationFieldDto defaultFieldWithSubfields(String tag) {
     return defaultField(tag).subfields(List.of(
-      getSubfield("a", true),
-      getSubfield("d", true),
-      getSubfield("k", false),
-      getSubfield("s", false),
-      getSubfield("0", false)));
+      getSubfield("a", true, true),
+      getSubfield("d", true, true),
+      getSubfield("k", false, true),
+      getSubfield("s", false, true),
+      getSubfield("0", false, true)));
+  }
+
+  private static SpecificationFieldDto defaultFieldWithNonRepeatableSubfields(String tag) {
+    return defaultField(tag).subfields(List.of(
+      getSubfield("a", true, true),
+      getSubfield("d", true, false),
+      getSubfield("k", false, true),
+      getSubfield("s", false, true),
+      getSubfield("c", false, true),
+      getSubfield("w", false, false)));
   }
 
   private static SpecificationFieldDto fieldDefinition(String tag, boolean required, boolean deprecated,
@@ -136,14 +165,14 @@ public class TestDataProvider {
       .tag(tag)
       .indicators(getFieldIndicatorDtoListByTag(tag))
       .subfields(List.of(
-        getSubfield("a", false),
-        getSubfield("b", false),
-        getSubfield("c", false),
-        getSubfield("d", false),
-        getSubfield("z", false),
-        getSubfield("0", false),
-        getSubfield("2", false),
-        getSubfield("9", false)))
+        getSubfield("a", false, true),
+        getSubfield("b", false, true),
+        getSubfield("c", false, true),
+        getSubfield("d", false, true),
+        getSubfield("z", false, true),
+        getSubfield("0", false, true),
+        getSubfield("2", false, true),
+        getSubfield("9", false, true)))
       .required(required)
       .deprecated(deprecated)
       .repeatable(repeatable);
@@ -189,12 +218,12 @@ public class TestDataProvider {
     return new FieldIndicatorDto().order(order).codes(indicatorCodeDto);
   }
 
-  private static SubfieldDto getSubfield(String code, boolean required) {
+  private static SubfieldDto getSubfield(String code, boolean required, boolean repeatable) {
     return new SubfieldDto()
       .id(UUID.randomUUID())
       .required(required)
       .deprecated(false)
-      .repeatable(true)
+      .repeatable(repeatable)
       .code(code);
   }
 }

--- a/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-non-repeatable-subfields-record.json
+++ b/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-non-repeatable-subfields-record.json
@@ -1,0 +1,122 @@
+{
+  "fields": [
+    {
+      "010": {
+        "ind1": "#",
+        "ind2": "#",
+        "subfields": [
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          }
+        ]
+      }
+    },
+    {
+      "035": {
+        "ind1": "#",
+        "ind2": "#",
+        "subfields": [
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          }
+        ]
+      }
+    },
+    {
+      "047": {
+        "ind1": "#",
+        "ind2": "#",
+        "subfields": [
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "w": "nonRepeatable subfield"
+          },
+          {
+            "w": "nonRepeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          }
+        ]
+      }
+    },
+    {
+      "100": {
+        "ind1": "0",
+        "ind2": "#",
+        "subfields": [
+          {
+            "a": "subfield value"
+          },
+          {
+            "d": ""
+          },
+          {
+            "d": "nonRepeatable subfield"
+          }
+        ]
+      }
+    },
+    {
+      "245": {
+        "ind1": "0",
+        "ind2": "0",
+        "subfields": [
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          }
+        ]
+      }
+    },
+    {
+      "650": {
+        "ind1": "0",
+        "ind2": "0",
+        "subfields": [
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "a": "repeatable subfield"
+          },
+          {
+            "d": "nonRepeatable subfield"
+          },
+          {
+            "w": "nonRepeatable subfield"
+          },
+          {
+            "w": "nonRepeatable subfield"
+          },
+          {
+            "c": "repeatable subfield"
+          },
+          {
+            "c": "repeatable subfield"
+          }
+        ]
+      }
+    }
+  ],
+  "leader": "01750ccm a2200421   4500"
+}

--- a/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-subfield-record.json
+++ b/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-subfield-record.json
@@ -45,9 +45,6 @@
             "d": "required subfield"
           },
           {
-            "d": ""
-          },
-          {
             "0": "optional subfield"
           }
         ]

--- a/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-subfield-record.json
+++ b/mod-record-specifications-validator/src/test/resources/testdata/subfields/marc-subfield-record.json
@@ -45,6 +45,9 @@
             "d": "required subfield"
           },
           {
+            "d": ""
+          },
+          {
             "0": "optional subfield"
           }
         ]

--- a/translations/mod-record-specifications/en.json
+++ b/translations/mod-record-specifications/en.json
@@ -32,5 +32,6 @@
   "validation.undefinedIndicatorCode": "{order} Indicator ''{code}'' is undefined.",
   "validation.invalidIndicator": "Indicator must contain one character and can only accept numbers 0-9, letters a-z or a '#'.",
   "validation.missingSubfield": "Subfield ''{code}'' is required.",
-  "validation.undefinedSubfield": "Subfield ''{code}'' is undefined."
+  "validation.undefinedSubfield": "Subfield ''{code}'' is undefined.",
+  "validation.nonRepeatableSubfield": "Subfield ''{code}'' is non-repeatable."
 }


### PR DESCRIPTION
### Purpose
[MRSPECS-48](https://folio-org.atlassian.net/browse/MRSPECS-48) implement "Non-Repeatable Subfield" Rule Validation 

### Approach
Validation fails when subfield is non-repeatable but exists more than once in a record's field

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Issue
Fix an issue with deprecated version of "actions/upload-artifact@v2" and "actions/download-artifact@v2" in the .github/workflows/build-dependants.yml file.
Links to issue: 
https://github.com/folio-org/mod-record-specifications/actions/runs/10790018166/attempts/4?pr=68
https://github.com/folio-org/mod-record-specifications/actions/runs/10790455327/job/29925897632?pr=68

Github Blog: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Log screenshots:
![image](https://github.com/user-attachments/assets/855b5bf2-17bc-40c7-97b0-5db77a4c014d)
![image](https://github.com/user-attachments/assets/578b002f-2bc6-4d4c-a326-0b33e7ce5808)

