### PR TITLE
fix(specification-sync): failed to parse some subfields

### DIFF
--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class MarcSpecificationSubfieldsBuilder {
 
   private static final Pattern SUBFIELD_PATTERN = Pattern.compile(
-    "\\s*\\$(?<%s>.) - (?<%s>.*?) \\((?<%s>\\w*)\\)(?<%s> \\[OBSOLETE])?"
+    "\\s*\\$(?<%s>.) - (?<%s>.*?) ?\\((?<%s>\\w*)\\)(?<%s> \\[OBSOLETE])?"
       .formatted(CODE_PROP, LABEL_PROP, REPEATABLE_PROP, DEPRECATED_PROP));
   private static final String NON_REPEATABLE_SIGN = "NR";
 

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/FullMarcSpecificationParserTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/FullMarcSpecificationParserTest.java
@@ -42,7 +42,7 @@ class FullMarcSpecificationParserTest {
     var result = doParseForFile("__files/marc/authority.html");
 
     assertThat(result).hasSize(147);
-    assertAllFieldsExist(result, 1668, 521);
+    assertAllFieldsExist(result, 1670, 521);
   }
 
   private void assertAllFieldsExist(ArrayNode result, int expectedSubfieldCount, int expectedIndicatorCodeCount) {


### PR DESCRIPTION
### Purpose
Failed to parse some subfields while specification sync.

### Approach
Adjust regex

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MRSPECS-67
