### PR TITLE
fix(specification-sync): empty url for deprecated fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Implement GET specification by id endpoint ([MRSPECS-50](https://folio-org.atlassian.net//browse/MRSPECS-50))
 * Sync specifications on new tenant creation ([MRSPECS-53](https://folio-org.atlassian.net//browse/MRSPECS-53))
 * Consume specification update request events ([MRSPECS-60](https://folio-org.atlassian.net//browse/MRSPECS-60))
+* Empty url for deprecated fields on sync specifications ([MRSPECS-70](https://folio-org.atlassian.net//browse/MRSPECS-70))
 
 #### Validator
 * implement validation by MARC specification ([MRSPECS-38](https://folio-org.atlassian.net//browse/MRSPECS-38))

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/SpecificationSyncService.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/SpecificationSyncService.java
@@ -97,10 +97,13 @@ public class SpecificationSyncService {
       var field = new Field();
       field.setId(UUID.fromString(fieldMetadata.id()));
       field.setTag(fieldMetadata.tag());
-      field.setUrl(baseFieldUrlFormat.formatted(field.getTag()));
       field.setScope(Scope.valueOf(fieldMetadata.scope()));
       field.setLabel(getText(fieldElement, LABEL_PROP));
-      field.setDeprecated(getBoolean(fieldElement, DEPRECATED_PROP));
+      var isDeprecated = getBoolean(fieldElement, DEPRECATED_PROP);
+      field.setDeprecated(isDeprecated);
+      if (!isDeprecated) {
+        field.setUrl(baseFieldUrlFormat.formatted(field.getTag()));
+      }
       field.setRepeatable(getBoolean(fieldElement, REPEATABLE_PROP));
       field.setRequired(isRequired(fieldElement, fieldMetadata));
       field.setSubfields(prepareSubfields(fieldElement.get(SUBFIELDS_PROP), fieldMetadata));


### PR DESCRIPTION
### Purpose
Set url to empty in case field is deprecated on specification sync.

### Approach
Adjust sync logic.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MRSPECS-70
