### PR TITLE
fix(specification-storage): Fix cache not being updated by dependant modules on specification update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 * Fix tenant upgrade not being ran on schema existence ([MRSPECS-71](https://folio-org.atlassian.net/browse/MRSPECS-71))
+* Fix cache not being updated by dependant modules on specification update ([MRSPECS-76](https://folio-org.atlassian.net/browse/MRSPECS-76))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -31,6 +31,9 @@
           "pathPattern": "/specification-storage/specifications/{specificationId}/sync",
           "permissionsRequired": [
             "specification-storage.specification.item.sync.execute"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -49,6 +52,9 @@
           "pathPattern": "/specification-storage/specifications/{specificationId}/rules/{ruleId}",
           "permissionsRequired": [
             "specification-storage.specification.rules.item.patch"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -67,6 +73,9 @@
           "pathPattern": "/specification-storage/specifications/{specificationId}/fields",
           "permissionsRequired": [
             "specification-storage.specification.fields.item.post"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -76,6 +85,9 @@
           "pathPattern": "/specification-storage/fields/{id}",
           "permissionsRequired": [
             "specification-storage.fields.item.put"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -85,6 +97,9 @@
           "pathPattern": "/specification-storage/fields/{id}",
           "permissionsRequired": [
             "specification-storage.fields.item.delete"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -103,6 +118,9 @@
           "pathPattern": "/specification-storage/fields/{fieldId}/subfields",
           "permissionsRequired": [
             "specification-storage.field.subfields.item.post"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -121,6 +139,9 @@
           "pathPattern": "/specification-storage/fields/{fieldId}/indicators",
           "permissionsRequired": [
             "specification-storage.field.indicators.item.post"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -130,6 +151,9 @@
           "pathPattern": "/specification-storage/indicators/{indicatorId}",
           "permissionsRequired": [
             "specification-storage.indicators.item.put"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -148,6 +172,9 @@
           "pathPattern": "/specification-storage/indicators/{indicatorId}/indicator-codes",
           "permissionsRequired": [
             "specification-storage.indicator.indicator-codes.item.post"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -157,6 +184,9 @@
           "pathPattern": "/specification-storage/indicator-codes/{indicatorCodeId}",
           "permissionsRequired": [
             "specification-storage.indicator-codes.item.put"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -166,6 +196,9 @@
           "pathPattern": "/specification-storage/indicator-codes/{indicatorCodeId}",
           "permissionsRequired": [
             "specification-storage.indicator-codes.item.delete"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -175,6 +208,9 @@
           "pathPattern": "/specification-storage/subfields/{subfieldId}",
           "permissionsRequired": [
             "specification-storage.subfields.item.put"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         },
         {
@@ -184,6 +220,9 @@
           "pathPattern": "/specification-storage/subfields/{subfieldId}",
           "permissionsRequired": [
             "specification-storage.subfields.item.delete"
+          ],
+          "modulePermissions": [
+            "specification-storage.specifications.item.get"
           ]
         }
       ]


### PR DESCRIPTION
### Purpose
Fix cache not being updated by dependant modules on specification update

### Approach
Include "get specification by id" permission to all modifying endpoints

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [x] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-76](https://folio-org.atlassian.net/browse/MRSPECS-76)
