### PR TITLE
fix(kafka): Fix specification.update consumer startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Fix cache not being updated by dependant modules on specification update ([MRSPECS-76](https://folio-org.atlassian.net/browse/MRSPECS-76))
 * Fix build dependants workflow ([MRSPECS-68](https://folio-org.atlassian.net/browse/MRSPECS-68))
 * Fix documentation generation github workflow  ([MRSPECS-78](https://folio-org.atlassian.net/browse/MRSPECS-78))
+* Fix specification.update consumer startup  ([MRSPECS-82](https://folio-org.atlassian.net/browse/MRSPECS-82))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/config/KafkaConfiguration.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/config/KafkaConfiguration.java
@@ -1,13 +1,18 @@
 package org.folio.rspec.config;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.folio.rspec.domain.dto.SpecificationUpdatedEvent;
 import org.folio.rspec.domain.dto.UpdateRequestEvent;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -58,8 +63,13 @@ public class KafkaConfiguration {
   }
 
   @Bean
-  public ConsumerFactory<String, UpdateRequestEvent> consumerFactory(KafkaProperties kafkaProperties) {
-    return new DefaultKafkaConsumerFactory<>(kafkaProperties.buildConsumerProperties(null),
+  public ConsumerFactory<String, UpdateRequestEvent> consumerFactory(
+    KafkaProperties kafkaProperties,
+    @Value("#{folioKafkaProperties.listener['update-requests'].autoOffsetReset}")
+    OffsetResetStrategy autoOffsetReset) {
+    var config = new HashMap<>(kafkaProperties.buildConsumerProperties(null));
+    config.put(AUTO_OFFSET_RESET_CONFIG, autoOffsetReset.toString());
+    return new DefaultKafkaConsumerFactory<>(config,
       new StringDeserializer(),
       new JsonDeserializer<>(UpdateRequestEvent.class));
   }

--- a/mod-record-specifications-server/src/main/resources/application-dev.yml
+++ b/mod-record-specifications-server/src/main/resources/application-dev.yml
@@ -62,6 +62,7 @@ folio:
         concurrency: 1
         topic-pattern: (${folio.environment}\.)(.*\.)specification-storage\.specification\.update
         group-id: ${folio.environment}-mod-record-specification-group
+        auto-offset-reset: EARLIEST
   logging:
     request:
       enabled: true

--- a/mod-record-specifications-server/src/main/resources/application.yml
+++ b/mod-record-specifications-server/src/main/resources/application.yml
@@ -62,6 +62,7 @@ folio:
         concurrency: 1
         topic-pattern: (${folio.environment}\.)(.*\.)specification-storage\.specification\.update
         group-id: ${folio.environment}-mod-record-specification-group
+        auto-offset-reset: EARLIEST
   logging:
     request:
       enabled: true


### PR DESCRIPTION
### Purpose
Fix specification.update consumer startup

### Approach
Set auto.offset.reset to EARLIEST so if mod-record-specifications starts in multiple instances and one instance sends specification.updated event earlier than second instance starts specification.update consumer - no messages from mod-entities-links are ignored

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-82](https://folio-org.atlassian.net/browse/MRSPECS-82)
[MODELINKS-298](https://folio-org.atlassian.net/browse/MODELINKS-298)
