### PR TITLE
feat(specification-sync): prefer non-obsolete entities no matter the order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Refactor specification sync from URL to local copy ([MRSPECS-87](https://folio-org.atlassian.net/browse/MRSPECS-87))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Fix non-obsolete subfield choosing logic ([MRSPECS-95](https://folio-org.atlassian.net/browse/MRSPECS-95))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/SpecificationSyncServiceTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/SpecificationSyncServiceTest.java
@@ -75,6 +75,63 @@ class SpecificationSyncServiceTest {
     assertThat(metadata.getFields()).containsOnlyKeys("111", "222", "333");
   }
 
+  @Test
+  void sync_shouldPreferNonObsoleteEntitiesOverObsoleteOnes() {
+    final var specId = randomUUID();
+    final var metadata = prepareMetadata();
+
+    var specification = new Specification();
+    specification.setId(specId);
+    specification.setFamily(Family.MARC);
+    specification.setProfile(FamilyProfile.BIBLIOGRAPHIC);
+
+    var fieldsArray = prepareFieldsWithDuplicates();
+    ArgumentCaptor<Collection<Field>> fieldsCaptor = ArgumentCaptor.captor();
+
+    when(metadataService.getSpecificationMetadata(specId)).thenReturn(metadata);
+    when(specificationFetcher.fetch(Family.MARC, FamilyProfile.BIBLIOGRAPHIC)).thenReturn(fieldsArray);
+    doNothing().when(specificationFieldService).syncFields(any(), fieldsCaptor.capture());
+
+    specificationSyncService.sync(specification);
+
+    var syncedFields = fieldsCaptor.getValue();
+
+    // Verify duplicate fields - should keep non-obsolete field
+    var fields856 = syncedFields.stream()
+      .filter(field -> "856".equals(field.getTag()))
+      .toList();
+    
+    assertThat(fields856).hasSize(1);
+    var field856 = fields856.getFirst();
+    assertThat(field856.isDeprecated()).isFalse();
+    assertThat(field856.getLabel()).isEqualTo("Electronic Location and Access (Non-obsolete)");
+
+    // Verify duplicate subfields - should keep non-obsolete subfield
+    var subfieldsH = field856.getSubfields().stream()
+      .filter(subfield -> "h".equals(subfield.getCode()))
+      .toList();
+    
+    assertThat(subfieldsH).hasSize(1);
+    var subfieldH = subfieldsH.getFirst();
+    assertThat(subfieldH.isDeprecated()).isFalse();
+    assertThat(subfieldH.getLabel()).isEqualTo("Non-functioning Uniform Resource Identifier");
+
+    // Verify duplicate indicator codes - should keep non-obsolete indicator code
+    var firstIndicator = field856.getIndicators().stream()
+      .filter(indicator -> 1 == indicator.getOrder())
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("First indicator not found"));
+
+    var indicatorCodes0 = firstIndicator.getCodes().stream()
+      .filter(code -> "0".equals(code.getCode()))
+      .toList();
+    
+    assertThat(indicatorCodes0).hasSize(1);
+    var indicatorCode0 = indicatorCodes0.getFirst();
+    assertThat(indicatorCode0.isDeprecated()).isFalse();
+    assertThat(indicatorCode0.getLabel()).isEqualTo("Email (Non-obsolete)");
+  }
+
   private ArrayNode prepareFetchedFields() {
     var fieldNode1 = prepareFieldNode("222", "label1", false, true, false);
     var fieldNode2 = prepareFieldNode("333", "label2", true, false, true);
@@ -103,5 +160,54 @@ class SpecificationSyncServiceTest {
     metadata.setFields(fieldsMetadata);
     metadata.setUrlFormat("format");
     return metadata;
+  }
+
+  private ArrayNode prepareFieldsWithDuplicates() {
+    var field856 = prepareFieldNode("856", "Electronic Location and Access (Non-obsolete)", false, true, false);
+    var subfieldsArray = JsonNodeFactory.instance.arrayNode();
+
+    // Add duplicate subfields: obsolete first, non-obsolete second
+    subfieldsArray.add(prepareSubfieldNode("Processor of request (NR) [OBSOLETE]", true, false));
+    subfieldsArray.add(prepareSubfieldNode("Non-functioning Uniform Resource Identifier", false, true));
+    field856.set("subfields", subfieldsArray);
+
+    var indicatorNode1 = JsonNodeFactory.instance.objectNode();
+    indicatorNode1.put("order", 1);
+    indicatorNode1.put("label", "Access method");
+
+    var indicatorCodesArray = JsonNodeFactory.instance.arrayNode();
+    // Add duplicate indicator codes: obsolete first, non-obsolete second
+    indicatorCodesArray.add(prepareIndicatorCodeNode("Email (Obsolete)", true));
+    indicatorCodesArray.add(prepareIndicatorCodeNode("Email (Non-obsolete)", false));
+    indicatorNode1.set("codes", indicatorCodesArray);
+
+    var indicatorsArray = JsonNodeFactory.instance.arrayNode();
+    indicatorsArray.add(indicatorNode1);
+    field856.set("indicators", indicatorsArray);
+
+    var fieldsArray = JsonNodeFactory.instance.arrayNode();
+    var obsoleteField856 = prepareFieldNode("856", "Electronic Location and Access (Obsolete)", true, true, false);
+    fieldsArray.add(obsoleteField856);
+    fieldsArray.add(field856);
+    return fieldsArray;
+  }
+
+  private ObjectNode prepareSubfieldNode(String label, boolean deprecated,
+                                         boolean repeatable) {
+    var subfieldNode = JsonNodeFactory.instance.objectNode();
+    subfieldNode.put("code", "h");
+    subfieldNode.put("label", label);
+    subfieldNode.put("deprecated", deprecated);
+    subfieldNode.put("repeatable", repeatable);
+    subfieldNode.put("required", false);
+    return subfieldNode;
+  }
+
+  private ObjectNode prepareIndicatorCodeNode(String label, boolean deprecated) {
+    var codeNode = JsonNodeFactory.instance.objectNode();
+    codeNode.put("code", "0");
+    codeNode.put("label", label);
+    codeNode.put("deprecated", deprecated);
+    return codeNode;
   }
 }


### PR DESCRIPTION
### Purpose
Prefer non-obsolete entities no matter the order

### Approach
Move deprecated comparison earlier in the process so subfields are chosen before being put to the set
Move indicator-codes/fields logic earlier as well

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-95](https://folio-org.atlassian.net/browse/MRSPECS-95)

### Learning and Resources (if applicable)
Subfields were collected and put in a set so same code subfields were not preserved, while deprecation comparison and preservation logic was implemented later in the process, where subfields for the same code were already gone because of the set.
