### PR TITLE
fix(specification-sync): Fix parsing obsolete subfields where there's no preceeding space

### DIFF
--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class MarcSpecificationSubfieldsBuilder {
 
   private static final Pattern SUBFIELD_PATTERN = Pattern.compile(
-    "\\s*\\$(?<%s>.) - (?<%s>.*?) ?\\((?<%s>\\w*)\\)(?<%s> \\[OBSOLETE])?"
+    "\\s*\\$(?<%s>.) - (?<%s>.*?) ?\\((?<%s>\\w*)\\)(?<%s> ?\\[OBSOLETE])?"
       .formatted(CODE_PROP, LABEL_PROP, REPEATABLE_PROP, DEPRECATED_PROP));
   private static final String NON_REPEATABLE_SIGN = "NR";
 

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationFieldBuilderTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationFieldBuilderTest.java
@@ -62,6 +62,8 @@ class MarcSpecificationFieldBuilderTest {
         createFieldNode("111", "My Non-Repeatable Field", false, false)),
       arguments("112 - My Deprecated Field (NR) [OBSOLETE]",
         createFieldNode("112", "My Deprecated Field [OBSOLETE]", false, true)),
+      arguments("113 - My Deprecated Field (NR)[OBSOLETE]",
+        createFieldNode("113", "My Deprecated Field [OBSOLETE]", false, true)),
       arguments("123 - My Repeatable Field 1 (Some Value)",
         createFieldNode("123", "My Repeatable Field 1", true, false)),
       arguments("124 - My Repeatable Field 2 (R)",

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationIndicatorBuilderTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationIndicatorBuilderTest.java
@@ -84,7 +84,7 @@ class MarcSpecificationIndicatorBuilderTest {
       );
 
     var lines5 = List.of(
-      "First - Indicator [OBSOLETE]",
+      "First - Indicator[OBSOLETE]",
       "# - Undefined",
       "First - Indicator With Codes1",
       "a - Code a",

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilderTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilderTest.java
@@ -27,24 +27,28 @@ class MarcSpecificationSubfieldsBuilderTest {
   }
 
   public static Stream<Arguments> provideParametersForBuildTest() {
-    List<String> lines1 = List.of("$1 - Name1 (NR)");
-    ArrayNode expected1 = MAPPER.createArrayNode().add(newNode("1", "Name1", false, false));
+    var lines1 = List.of("$1 - Name1 (NR)");
+    var expected1 = MAPPER.createArrayNode().add(newNode("1", "Name1", false, false));
 
-    List<String> lines2 = List.of("$2 - Name2 (NR) [OBSOLETE]");
-    ArrayNode expected2 = MAPPER.createArrayNode().add(newNode("2", "Name2", false, true));
+    var lines2 = List.of("$2 - Name2 (NR) [OBSOLETE]");
+    var expected2 = MAPPER.createArrayNode().add(newNode("2", "Name2", false, true));
 
-    List<String> lines3 = List.of("$a - Name3 (R)");
-    ArrayNode expected3 = MAPPER.createArrayNode().add(newNode("a", "Name3", true, false));
+    var lines3 = List.of("$a - Name3 (R)");
+    var expected3 = MAPPER.createArrayNode().add(newNode("a", "Name3", true, false));
+
+    var lines4 = List.of("$b - Name4 (NR)[OBSOLETE]");
+    var expected4 = MAPPER.createArrayNode().add(newNode("b", "Name4", false, true));
 
     return Stream.of(
       Arguments.of(lines1, expected1),
       Arguments.of(lines2, expected2),
-      Arguments.of(lines3, expected3)
+      Arguments.of(lines3, expected3),
+      Arguments.of(lines4, expected4)
     );
   }
 
   private static ObjectNode newNode(String code, String label, boolean repeatable, boolean deprecated) {
-    ObjectNode node = MAPPER.createObjectNode();
+    var node = MAPPER.createObjectNode();
     node.put("code", code);
     node.put("label", label);
     node.put("repeatable", repeatable);


### PR DESCRIPTION
### Purpose
Fix parsing obsolete subfields where there's no preceeding space

### Approach
Make space before obsolete optional in a subfield line regexp

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-95](https://folio-org.atlassian.net/browse/MRSPECS-95)
