### PR TITLE
fix(marc-bib-subfields-spec) Fix some "[OBSOLETE]" subfields are not "deprecated" or not exist in MARC specification.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 * Fix non-obsolete subfield choosing logic ([MRSPECS-95](https://folio-org.atlassian.net/browse/MRSPECS-95))
+* Fix some "[OBSOLETE]" subfields are not "deprecated" or not exist in MARC specification ([MRSPECS-99](https://folio-org.atlassian.net/browse/MRSPECS-99))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
+++ b/mod-record-specifications-server/src/main/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilder.java
@@ -19,8 +19,14 @@ import org.springframework.stereotype.Component;
 public class MarcSpecificationSubfieldsBuilder {
 
   private static final Pattern SUBFIELD_PATTERN = Pattern.compile(
-    "\\s*\\$(?<%s>.) - (?<%s>.*?) ?\\((?<%s>\\w*)\\)(?<%s> ?\\[OBSOLETE])?"
-      .formatted(CODE_PROP, LABEL_PROP, REPEATABLE_PROP, DEPRECATED_PROP));
+    ("^\\$(?<%s>.) - (?<%s>.+?)"                  // Code and label
+      + "(?:\\s*\\((?<%s>R|NR)\\))?"              // Optional (R|NR)
+      + "(?:\\s*\\([^)]*\\))?"                    // Optional cataloging level (ignored) (e.g. (MU VM SE))
+      + "(?:\\s*\\[(?<%s>OBSOLETE)\\])?"          // Optional [OBSOLETE]
+      + "(?:\\s*\\[[^\\]]+\\])?"                  // Optional tags (ignored) (e.g. [LOCAL])
+      + "\\s*$")
+      .formatted(CODE_PROP, LABEL_PROP, REPEATABLE_PROP, DEPRECATED_PROP)
+  );
   private static final String NON_REPEATABLE_SIGN = "NR";
 
   private final ObjectMapper objectMapper;

--- a/mod-record-specifications-server/src/test/java/org/folio/api/SpecificationStorageSyncApiIT.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/api/SpecificationStorageSyncApiIT.java
@@ -66,7 +66,7 @@ class SpecificationStorageSyncApiIT extends SpecificationITBase {
       .containsExactlyInAnyOrder(createdFieldIds);
 
     assertThat(recreatedSubfields)
-      .hasSize(2832)
+      .hasSize(2840)
       .extracting(UuidPersistable::getId)
       .containsExactlyInAnyOrder(createdSubfieldIds);
 

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/FullMarcSpecificationParserTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/FullMarcSpecificationParserTest.java
@@ -33,7 +33,7 @@ class FullMarcSpecificationParserTest {
     var result = doParseForFile("spec/marc/bibliographic.html");
 
     assertThat(result).hasSize(293);
-    assertAllFieldsExist(result, 2809, 1130);
+    assertAllFieldsExist(result, 2817, 1130);
   }
 
   @SneakyThrows

--- a/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilderTest.java
+++ b/mod-record-specifications-server/src/test/java/org/folio/rspec/service/sync/fetcher/MarcSpecificationSubfieldsBuilderTest.java
@@ -39,11 +39,47 @@ class MarcSpecificationSubfieldsBuilderTest {
     var lines4 = List.of("$b - Name4 (NR)[OBSOLETE]");
     var expected4 = MAPPER.createArrayNode().add(newNode("b", "Name4", false, true));
 
+    var lines5 = List.of("$b - Name5 (NR) (MU VM SE) [OBSOLETE]");
+    var expected5 = MAPPER.createArrayNode().add(newNode("b", "Name5", false, true));
+
+    var lines6 = List.of("$b - Name6 (R) (MU VM SE) [OBSOLETE]");
+    var expected6 = MAPPER.createArrayNode().add(newNode("b", "Name6", true, true));
+
+    var lines7 = List.of("$b - Name7 (Pre-AACR 2) (NR) [LOCAL]");
+    var expected7 = MAPPER.createArrayNode().add(newNode("b", "Name7 (Pre-AACR 2)", false, false));
+
+    var lines8 = List.of("$b - Name8");
+    var expected8 = MAPPER.createArrayNode().add(newNode("b", "Name8", true, false));
+
+    var lines9 = List.of("$a - Content of non-MARC field (NR)");
+    var expected9 = MAPPER.createArrayNode().add(newNode("a", "Content of non-MARC field", false, false));
+
+    var lines10 = List.of("$l - ISSN-L (NR) [OBSOLETE]");
+    var expected10 = MAPPER.createArrayNode().add(newNode("l", "ISSN-L", false, true));
+
+    var lines11 = List.of("$b - Date 1 (B.C.E. date) (NR)");
+    var expected11 = MAPPER.createArrayNode().add(newNode("b", "Date 1 (B.C.E. date)", false, false));
+
+    var lines12 = List.of("$b - DDC number--abridged NST version (SE) [OBSOLETE]");
+    var expected12 = MAPPER.createArrayNode().add(newNode("b", "DDC number--abridged NST version", true, true));
+
+    var lines13 = List.of("$b - Number  [OBSOLETE]");
+    var expected13 = MAPPER.createArrayNode().add(newNode("b", "Number", true, true));
+
     return Stream.of(
       Arguments.of(lines1, expected1),
       Arguments.of(lines2, expected2),
       Arguments.of(lines3, expected3),
-      Arguments.of(lines4, expected4)
+      Arguments.of(lines4, expected4),
+      Arguments.of(lines5, expected5),
+      Arguments.of(lines6, expected6),
+      Arguments.of(lines7, expected7),
+      Arguments.of(lines8, expected8),
+      Arguments.of(lines9, expected9),
+      Arguments.of(lines10, expected10),
+      Arguments.of(lines11, expected11),
+      Arguments.of(lines12, expected12),
+      Arguments.of(lines13, expected13)
     );
   }
 


### PR DESCRIPTION
### Purpose
Some subfields which have "[OBSOLETE]" label in MARC Standard (https://www.loc.gov/marc/bibliographic/ecbdlist.html) have "deprecated": false value in MARC specification. Some "[OBSOLETE]" subfields even doesn’t exist in MARC specification.

Issues found for following subfields of MARC bib specification:

- Subfields “b”, “d”, “e” are not deprecated in “850” field
- Subfield “q” is not deprecated in “760”, “762”, “765”, “767”, “770”, “772”, “775”, “776”, “777”, “780”, “785” fields.
- Obsolete subfield “b” doesn’t exist in specification of “611”, “711” fields 
- Subfield “z” is not deprecated in “515”, “525”, “530” fields
- Obsolete subfield “z” doesn’t exist in specification of “500” field
- Obsolete subfield “b” doesn’t exist in specification of “411” field
- Obsolete subfields “d” and “e” don’t exist in specification of “242” field
- Obsolete subfield “b” doesn’t exist in specification of “111” field
- Subfield “1” doesn’t exist in specification of “340” MARC bib field

### Approach
Updated the `SUBFIELD_PATTERN` regex to support optional _cataloging level_ information in subfield parsing

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots (if applicable)
850 field:
<img width="1633" height="853" alt="image" src="https://github.com/user-attachments/assets/159a99c7-d214-4934-9590-b0f899ad193e" />

760 field: 
<img width="1645" height="798" alt="image" src="https://github.com/user-attachments/assets/e0c17cc6-9a5d-4ebb-9d85-ff73f4981650" />

611 field:
<img width="1641" height="748" alt="image" src="https://github.com/user-attachments/assets/e1bd81b8-2795-40bb-af7d-ed0b4952fcbe" />

711 field:
<img width="1638" height="787" alt="image" src="https://github.com/user-attachments/assets/ee5ac8f6-e7d6-488f-a4a3-c3419983ca2c" />

530 field:
<img width="1648" height="793" alt="image" src="https://github.com/user-attachments/assets/5a43ce35-c8e1-44b0-aba8-c3857c27bbeb" />

500 field:
<img width="1638" height="800" alt="image" src="https://github.com/user-attachments/assets/febcce36-14c0-41eb-be5f-9ac1c5d61d50" />

411 field:
<img width="1627" height="781" alt="image" src="https://github.com/user-attachments/assets/ab4c5dcb-3fd7-4f03-b5b2-b5e9846ac95a" />

242 field:
<img width="1614" height="848" alt="image" src="https://github.com/user-attachments/assets/3928b973-a7e6-492d-b487-310df03ac67b" />

111 field:
<img width="1729" height="764" alt="image" src="https://github.com/user-attachments/assets/00e75a7d-ffbc-44fa-823f-d5c76e3cc5c8" />

340 field: 
<img width="1633" height="780" alt="image" src="https://github.com/user-attachments/assets/61543728-93d2-4d83-9572-f0878fe4d031" />




