### PR TITLE
chore: add script to update MARC bib field '590'

### DIFF
--- a/mod-record-specifications-server/src/main/resources/db/scripts/20260520_update_marc_bib_590.sql
+++ b/mod-record-specifications-server/src/main/resources/db/scripts/20260520_update_marc_bib_590.sql
@@ -1,0 +1,21 @@
+-- Script for https://folio-org.atlassian.net/browse/MRSPECS-202
+
+-- Replace ${tenantId} placeholder with specific tenant id
+SET SEARCH_PATH = ${tenantId}_mod_record_specifications;
+
+-- Update field '590' to be non-deprecated and make its subfield 'd' repeatable in the MARC bibliographic specification.
+WITH updated_field AS (
+    UPDATE field f
+    SET deprecated = false
+    FROM specification s
+    WHERE f.specification_id = s.id
+      AND f.tag = '590'
+      AND s.family = 'MARC'::family_enum
+      AND s.profile = 'BIBLIOGRAPHIC'::family_profile_enum
+    RETURNING f.id
+)
+UPDATE subfield sf
+SET repeatable = true
+FROM updated_field f
+WHERE sf.field_id = f.id
+  AND sf.code = 'd';

--- a/mod-record-specifications-server/src/main/resources/db/scripts/20260520_update_marc_bib_590.sql
+++ b/mod-record-specifications-server/src/main/resources/db/scripts/20260520_update_marc_bib_590.sql
@@ -3,19 +3,33 @@
 -- Replace ${tenantId} placeholder with specific tenant id
 SET SEARCH_PATH = ${tenantId}_mod_record_specifications;
 
--- Update field '590' to be non-deprecated and make its subfield 'd' repeatable in the MARC bibliographic specification.
+-- Update field '590' to be non-deprecated and set scope to LOCAL in MARC bibliographic specification
 WITH updated_field AS (
     UPDATE field f
-    SET deprecated = false
+    SET deprecated = false,
+        scope = 'LOCAL'
     FROM specification s
     WHERE f.specification_id = s.id
       AND f.tag = '590'
       AND s.family = 'MARC'::family_enum
       AND s.profile = 'BIBLIOGRAPHIC'::family_profile_enum
     RETURNING f.id
+),
+-- Update subfields of field '590' to set scope to LOCAL and make subfield 'd' repeatable
+updated_subfield AS (
+    UPDATE subfield sf
+    SET scope = 'LOCAL',
+        repeatable = CASE
+            WHEN sf.code = 'd' THEN true
+            ELSE repeatable
+        END
+    FROM updated_field f
+    WHERE sf.field_id = f.id
+    RETURNING 1
 )
-UPDATE subfield sf
-SET repeatable = true
-FROM updated_field f
-WHERE sf.field_id = f.id
-  AND sf.code = 'd';
+-- Update indicator codes of field '590' to set scope to LOCAL
+UPDATE indicator_code ic
+SET scope = 'LOCAL'
+FROM indicator i, updated_field f
+WHERE ic.indicator_id = i.id
+  AND i.field_id = f.id;


### PR DESCRIPTION
### Purpose
-  need a script to change at the DB level deprecated field 590 and its indicators and subfields to local.  
- set deprecated = false to the field
- set $d repeatable = true

### Approach
- add a script to update field 590 to be local and non-deprecated, make its subfield d repeatable, and set all its indicators and subfields to local.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MRSPECS-202](https://folio-org.atlassian.net/browse/MRSPECS-202)
